### PR TITLE
Support dataloader kwargs in AIRL

### DIFF
--- a/src/imitation/algorithms/adversarial/airl.py
+++ b/src/imitation/algorithms/adversarial/airl.py
@@ -1,5 +1,5 @@
 """Adversarial Inverse Reinforcement Learning (AIRL)."""
-from typing import Optional
+from typing import Mapping, Optional
 
 import torch as th
 from stable_baselines3.common import base_class, policies, vec_env
@@ -26,6 +26,7 @@ class AIRL(common.AdversarialTrainer):
         venv: vec_env.VecEnv,
         gen_algo: base_class.BaseAlgorithm,
         reward_net: reward_nets.RewardNet,
+        demo_data_loader_kwargs: Optional[Mapping] = None,
         **kwargs,
     ):
         """Builds an AIRL trainer.
@@ -43,6 +44,8 @@ class AIRL(common.AdversarialTrainer):
                 discriminator confusion. Environment and logger will be set to
                 `venv` and `custom_logger`.
             reward_net: Reward network; used as part of AIRL discriminator.
+            demo_data_loader_kwargs: Optional kwargs passed to
+                :func:`imitation.algorithms.base.make_data_loader`.
             **kwargs: Passed through to `AdversarialTrainer.__init__`.
 
         Raises:
@@ -56,6 +59,7 @@ class AIRL(common.AdversarialTrainer):
             venv=venv,
             gen_algo=gen_algo,
             reward_net=reward_net,
+            demo_data_loader_kwargs=demo_data_loader_kwargs,
             **kwargs,
         )
         # AIRL needs a policy from STOCHASTIC_POLICIES to compute discriminator output.

--- a/src/imitation/algorithms/adversarial/common.py
+++ b/src/imitation/algorithms/adversarial/common.py
@@ -118,6 +118,7 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
         gen_algo: base_class.BaseAlgorithm,
         reward_net: reward_nets.RewardNet,
         demo_minibatch_size: Optional[int] = None,
+        demo_data_loader_kwargs: Optional[Mapping] = None,
         n_disc_updates_per_round: int = 2,
         log_dir: types.AnyPath = "output/",
         disc_opt_cls: Type[th.optim.Optimizer] = th.optim.Adam,
@@ -154,6 +155,10 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
                 facilitating training with larger batch sizes, but is
                 generally slower. Must be a factor of `demo_batch_size`.
                 Optional, defaults to `demo_batch_size`.
+            demo_data_loader_kwargs: Optional kwargs passed to
+                :func:`imitation.algorithms.base.make_data_loader`. Use this to
+                set DataLoader options like ``num_workers`` for faster
+                demonstration loading.
             n_disc_updates_per_round: The number of discriminator updates after each
                 round of generator updates in AdversarialTrainer.learn().
             log_dir: Directory to store TensorBoard logs, plots, etc. in.
@@ -192,6 +197,7 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
         self.demo_minibatch_size = demo_minibatch_size or demo_batch_size
         if self.demo_batch_size % self.demo_minibatch_size != 0:
             raise ValueError("Batch size must be a multiple of minibatch size.")
+        self.demo_data_loader_kwargs = dict(demo_data_loader_kwargs or {})
         self._demo_data_loader = None
         self._endless_expert_iterator = None
         super().__init__(
@@ -307,6 +313,7 @@ class AdversarialTrainer(base.DemonstrationAlgorithm[types.Transitions]):
         self._demo_data_loader = base.make_data_loader(
             demonstrations,
             self.demo_batch_size,
+            data_loader_kwargs=self.demo_data_loader_kwargs,
         )
         self._endless_expert_iterator = util.endless_iter(self._demo_data_loader)
 


### PR DESCRIPTION
## Summary
- allow passing `demo_data_loader_kwargs` to AIRL and other adversarial trainers
- forward these kwargs to `make_data_loader`

## Testing
- `pre-commit run --files src/imitation/algorithms/adversarial/airl.py src/imitation/algorithms/adversarial/common.py` *(fails: pytype and docs missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fa28694f4832585c66ed09b70de29